### PR TITLE
fix bug java.nio.BufferOverflowException in jre1.8.0_181

### DIFF
--- a/src/main/java/org/ebml/EBMLReader.java
+++ b/src/main/java/org/ebml/EBMLReader.java
@@ -279,7 +279,12 @@ public class EBMLReader
     if (numBytes > 1)
     {
       // Read the rest of the size.
-      data.put(source);
+      //data.put(source);
+      // bug java.nio.BufferOverflowException
+      for (int i = 1; i < numBytes; i++)
+      {
+        data.put(source.get());
+      }
     }
     data.flip();
     return parseEBMLCode(data);
@@ -311,7 +316,12 @@ public class EBMLReader
     if (numBytes > 1)
     {
       // Read the rest of the size.
-      data.put(source);
+      //data.put(source);
+      // bug java.nio.BufferOverflowException
+      for (int i = 1; i < numBytes; i++)
+      {
+        data.put(source.get());
+      }
     }
     data.flip();
     // Put this into a long

--- a/src/main/java/org/ebml/EBMLReader.java
+++ b/src/main/java/org/ebml/EBMLReader.java
@@ -276,16 +276,12 @@ public class EBMLReader
     // Clear the 1 at the front of this byte, all the way to the beginning of the size
     data.put((byte) (firstByte & ((0xFF >>> (numBytes)))));
 
-    if (numBytes > 1)
+    // Read the rest of the size.
+    for (int i = 1; i < numBytes; i++)
     {
-      // Read the rest of the size.
-      //data.put(source);
-      // bug java.nio.BufferOverflowException
-      for (int i = 1; i < numBytes; i++)
-      {
-        data.put(source.get());
-      }
+      data.put(source.get());
     }
+
     data.flip();
     return parseEBMLCode(data);
   }
@@ -313,16 +309,12 @@ public class EBMLReader
     // Clear the 1 at the front of this byte, all the way to the beginning of the size
     data.put((byte) (firstByte & ((0xFF >>> (numBytes)))));
 
-    if (numBytes > 1)
+    // Read the rest of the size.
+    for (int i = 1; i < numBytes; i++)
     {
-      // Read the rest of the size.
-      //data.put(source);
-      // bug java.nio.BufferOverflowException
-      for (int i = 1; i < numBytes; i++)
-      {
-        data.put(source.get());
-      }
+      data.put(source.get());
     }
+
     data.flip();
     // Put this into a long
     long size = parseEBMLCode(data);


### PR DESCRIPTION
there is a bug when `ByteBuffer source` bigger then `ByteBuffer data` and then `data.put(source)` will throw an Exception `java.nio.BufferOverflowException`
version: jre1.8.0_181